### PR TITLE
remove references to shared snakemake

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rename the output file `samples_template.tsv` as `samples.tsv`.
 
 3. A file named `grouped_contigs.tsv` with a column named 'name' and a second column named 'contigs' containing comma-delimited sequence names (chromosome/contig names) is needed. You may run `Rscript group_contigs.R` to generate this file based on the reference sequence listed in `config.yaml`.
 
-4. Submit job with `sbatch -p bbc bin/run_snakemake.sh`. 
+4. Submit job with `sbatch -p <parition name: e.g., long or bbc> bin/run_snakemake.sh`. 
 
 # Workflow
 

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -13,8 +13,6 @@ ref:
     snpEff_dataDir: "./data/"
     snpEff_genome_ID: "WBcel235.105"
 
-shared_snakemake_repo: "/secondary/projects/bbc/research/shared_snakemake/"
-
 modules:
   bamtools: bbc2/bamtools/bamtools-2.5.2
   bcftools: bbc2/bcftools/bcftools-1.17


### PR DESCRIPTION
Instead of relying on the shared snakemake, this just incorporates those 3 rules directly into the pipeline. 

I also updated the README to provide different examples of the partitions to submit to, so that other users don't try submitting to the BBC partition. I can revert this or shorten it if it's needlessly complicated, though.